### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "aaemnnosttv/wp-cli-http-command",
     "description": "WP-CLI command for using the WordPress HTTP API",
+    "type": "wp-cli-package",
     "require": {
         "php": "^5.5 | ^7.0"
     },


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
